### PR TITLE
Slack bot Implementaton

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,19 +10,15 @@ lazy val root = (project in file("."))
       "org.http4s" %% "http4s-ember-client" % "0.23.30",
       "org.http4s" %% "http4s-dsl" % "0.23.30",
       "org.http4s" %% "http4s-circe" % "0.23.30",
-
       "com.softwaremill.sttp.tapir" %% "tapir-core" % "1.11.33",
       "com.softwaremill.sttp.tapir" %% "tapir-http4s-server" % "1.11.33",
       "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % "1.11.33",
       "com.softwaremill.sttp.tapir" %% "tapir-swagger-ui-bundle" % "1.11.33",
-
       "io.circe" %% "circe-core" % "0.14.10",
       "io.circe" %% "circe-generic" % "0.14.10",
       "io.circe" %% "circe-parser" % "0.14.10",
-
       "org.typelevel" %% "cats-effect" % "3.5.7",
       "org.slf4j" % "slf4j-simple" % "2.0.16",
-
       "com.softwaremill.sttp.client3" %% "core" % "3.10.1",
       "com.softwaremill.sttp.client3" %% "circe" % "3.10.1",
       "com.softwaremill.sttp.client3" %% "http4s-backend" % "3.10.1",

--- a/src/main/scala/com/slackbot/Main.scala
+++ b/src/main/scala/com/slackbot/Main.scala
@@ -36,7 +36,7 @@ object Main extends IOApp {
       allRoutes = slackRoutes.routes <+> swaggerRoutes
 
       finalRoutes = Logger.httpRoutes(true, true)(CORS.policy.withAllowOriginAll(allRoutes))
-
+//My scala server for all function.
       _ <- EmberServerBuilder
         .default[IO]
         .withHost(Host.fromString(config.server.host).getOrElse(ipv4"0.0.0.0"))

--- a/src/main/scala/com/slackbot/api/SlackEndPoints.scala
+++ b/src/main/scala/com/slackbot/api/SlackEndPoints.scala
@@ -6,7 +6,7 @@ import sttp.tapir.json.circe.*
 import io.circe.generic.auto.*
 
 object SlackEndPoints {
-  
+
   case class SendMessageRequest(
                                  channel: String,
                                  message: String,
@@ -17,13 +17,13 @@ object SlackEndPoints {
                                   success: Boolean,
                                   messageId: String
                                 )
-  
+
   case class InteractiveResponse(
                                   message: String,
                                   action: String,
                                   user: String
                                 )
-
+//Endpoint for sending or a request message
   val sendMessageEndpoint: PublicEndpoint[SendMessageRequest, String, SendMessageResponse, Any] =
     endpoint.post
       .in("slack" / "send")
@@ -32,7 +32,7 @@ object SlackEndPoints {
       .errorOut(stringBody)
       .name("Send Interactive Message")
       .description("Send a message with Accept/Decline buttons to Slack")
-
+//Endpoint for interaction after clicking on accept/decline buttonn
   val interactiveCallbackEndpoint: PublicEndpoint[String, String, InteractiveResponse, Any] =
     endpoint.post
       .in("slack" / "interactive")
@@ -41,7 +41,7 @@ object SlackEndPoints {
       .errorOut(stringBody)
       .name("Handle Interactive Callback")
       .description("Handle button clicks from Slack interactive messages")
-
+//A crucial endpoint for checking healthpoints provided by slack
   val healthEndpoint: PublicEndpoint[Unit, String, String, Any] =
     endpoint.get
       .in("health")

--- a/src/main/scala/com/slackbot/api/SlackEndPoints.scala
+++ b/src/main/scala/com/slackbot/api/SlackEndPoints.scala
@@ -32,7 +32,7 @@ object SlackEndPoints {
       .errorOut(stringBody)
       .name("Send Interactive Message")
       .description("Send a message with Accept/Decline buttons to Slack")
-//Endpoint for interaction after clicking on accept/decline buttonn
+//Endpoint for interaction after clicking on accept/decline button
   val interactiveCallbackEndpoint: PublicEndpoint[String, String, InteractiveResponse, Any] =
     endpoint.post
       .in("slack" / "interactive")

--- a/src/main/scala/com/slackbot/api/SlackRoutes.scala
+++ b/src/main/scala/com/slackbot/api/SlackRoutes.scala
@@ -20,7 +20,7 @@ class SlackRoutes(slackClient: SlackClient) {
   private def sendMessage(request: SendMessageRequest): IO[Either[String, SendMessageResponse]] = {
     val messageId = request.messageId.getOrElse(UUID.randomUUID().toString)
 
-    // Now testing with interactive buttons
+    // Now testing with interactive buttons in Slack
     val interactiveMessage = slackClient.createInteractiveMessage(
       channel = request.channel,
       text = request.message,

--- a/src/main/scala/com/slackbot/client/SlackClient.scala
+++ b/src/main/scala/com/slackbot/client/SlackClient.scala
@@ -18,7 +18,7 @@ class SlackClient(botToken: String) {
       val jsonPayload = message.asJson
 
       println(s"Sending JSON to Slack: ${jsonPayload.spaces2}")
-
+     // API call to Slack
       val request = basicRequest
         .post(uri"https://slack.com/api/chat.postMessage")
         .header("Authorization", s"Bearer $botToken")
@@ -43,6 +43,7 @@ class SlackClient(botToken: String) {
       }
     }
   }
+  //Interactivty after clicking on buttons
   def createInteractiveMessage(channel: String, text: String, messageId: String = "approval_request"): SlackMessage = {
     val blocks = List(
       SlackBlock(

--- a/src/main/scala/com/slackbot/client/SlackClient.scala
+++ b/src/main/scala/com/slackbot/client/SlackClient.scala
@@ -47,7 +47,7 @@ class SlackClient(botToken: String) {
     val blocks = List(
       SlackBlock(
         `type` = "section",
-        text = Some(SlackText(`type` = "mrkdwn", text = text)) // No emoji field for mrkdwn
+        text = Some(SlackText(`type` = "mrkdwn", text = text)) 
       ),
       SlackBlock(
         `type` = "actions",

--- a/src/main/scala/com/slackbot/config/config.scala
+++ b/src/main/scala/com/slackbot/config/config.scala
@@ -1,5 +1,5 @@
 package com.slackbot.config
-
+//config file !!
 import pureconfig._
 case class SlackConfig(
                         botToken: String,

--- a/src/main/scala/com/slackbot/models/SlackModels.scala
+++ b/src/main/scala/com/slackbot/models/SlackModels.scala
@@ -34,7 +34,7 @@ case class SlackText(
                       text: String,
                       emoji: Option[Boolean] = None
                     )
-
+//Payload requirement as per slack json package
 case class SlackInteractivePayload(
                                     `type`: String,
                                     user: SlackUser,


### PR DESCRIPTION
## Slack Bot Implementation

This PR contains the complete Slack bot implementation with:

- Interactive message sending with Accept/Decline buttons
- Swagger API documentation
- Configuration management
- HTTP4s server with Tapir endpoints

### Features
- `/slack/send` - Send messages with interactive buttons
- `/slack/interactive` - Handle button click callbacks  
- `/health` - Health check endpoint
- Swagger UI at `/docs`

### Tech Stack
- Scala 3
- HTTP4s + Tapir
- Circe for JSON
- PureConfig for configuration

As this is a PR just for review of my code and a feedback not to literally to put a change...